### PR TITLE
Throw a more meaningful ex-info if the routes file does not exist

### DIFF
--- a/examples/routes.txt
+++ b/examples/routes.txt
@@ -1,0 +1,1 @@
+GET / home

--- a/project.clj
+++ b/project.clj
@@ -9,4 +9,5 @@
                  ]
   :profiles {:dev {:dependencies [[midje "1.6.3"]
                                   [ring-mock "0.1.5"]]
+                   :resource-paths ["examples"]
                      :plugins [[lein-midje "3.1.1"]]}})

--- a/src/scenic/routes.clj
+++ b/src/scenic/routes.clj
@@ -48,7 +48,9 @@
            (map process-route-vector))])
 
 (defn load-routes-from-file [file]
-  (load-routes (slurp (io/resource file))))
+  (if (.exists (io/file file))
+    (load-routes (slurp file))
+    (throw (ex-info "Routes file not found" {:path file}))))
 
 ; TODO validate request method
 

--- a/test/scenic/test/routes.clj
+++ b/test/scenic/test/routes.clj
@@ -1,6 +1,6 @@
 (ns scenic.test.routes
   (:require [midje.sweet :refer :all]
-            [scenic.routes :refer [load-routes scenic-handler]]
+            [scenic.routes :refer [load-routes scenic-handler load-routes-from-file]]
             [bidi.bidi :refer [path-for match-route]]
             [ring.mock.request :refer [request]]
             ))
@@ -19,6 +19,12 @@
              => ["" [["/" {:get :home}]
                      ["/hello" {:get :hello}]]])
        (future-fact "support contexts "))
+
+(facts "Can load routes from file"
+       (fact "loads routes from a file"
+             (load-routes-from-file "examples/routes.txt") => ["" '(["/" {:get :home}])])
+       (fact "throws exception when the file doesn't exist"
+             (load-routes-from-file "xxx") => (throws Exception)))
 
 (facts "about scenic-handler"
  (fact "can make handler from routes file and handler map"


### PR DESCRIPTION
Clojure's default exception for missing files is rather unhelpful, it also feels like it's better to blow up as soon as we know the routes file is missing.
